### PR TITLE
Fixes in innocent.jpg.hqx

### DIFF
--- a/raw_files/innocent.jpg.hqx
+++ b/raw_files/innocent.jpg.hqx
@@ -11,7 +11,7 @@
 !!!!!!6K#58d$q!!!!!!!F!!!rrrrrrrrrrrrrrrrrrrrrrrrrrrrr`2S!!!!!2r
 rrrrrrrrrrrrrrrrrrrrrrrrrrrm$k!!!!!$rrrrrrrrrrrrrrrrrrrrrrrrrrrr
 r!qJ!!!!!rrrrrrrrrrrrrrrrrrrrrrrrrrrrr`2S!!!i3NP0"!J!!!!!!"!!!!!
-"!!!#3!!!!N!!!!!!l%**6338!!!!!!!%!!!!#MK#58d%"J!!!!!!"`!!!!!!!3%
+"!!!#3!!!!N!!!!!!1%**6338!!!!!!!%!!!!#MK#58d%"J!!!!!!"`!!!!!!!3%
 !rq)#,%P$3ep38Np'58a&!!%"!!!#(%&%3N8#%!!!E@jdFP*(3L"B@9SJ"mm!!`!
 G!!!!'J!eB@0cF%&38%`!!!!!EQpZC3!!!!!!!!!!!!!!!!!!!!!!!2E@!!%!!!!
 !dbe"4%*&!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -38,7 +38,7 @@ c4T5NKE59a06Np+@eaGAPp9CQGSD@TVE'eZEf*cG(9fGhKjHRYmIrfJ!-!`%!!K%
 $%3!r!23%NNNP+556*+A6%J+$l30"U815G58P`LQhK0[3Lj4h&&2#Qp3+3HdU[+8
 T*i!fC#G9Jk%GMJiD),#+C****)8NNNNT55555Rrrd23%NNNP,)0edHe[2G%XGYD
 51HbVHRVZGbPVdA4(8VX"j+FZ6&dF+-T$64NTH8T3h@KUB@JTF3645&bKkU'pqZL
-P@ce`iGqbEC*d63!eC#d&%V-[jK$p,p&ZMh$P-ahZ%m*'l#$4"G!*e&Nl4h8NjJ8
+P@ce!iGqbEC*d63!eC#d&%V-[jK$p,p&ZMh$P-ahZ%m*'l#$4"G!*e&Nl4h8NjJ8
 NNNNT55555RrrdI3%NNNP)Ec!#!ka&bHbU%TNT%D"QJ0%Qk8*lb$#F&3Xe61+a4h
 C!%Q2@,(NZe4Aiaefr*,'CYphhUa2LB#P!&DXFT'p(20,qBl`VQ23jQTlK'D'aST
 GNJ!&XTNk)S'SM3UZ+`flDH1b)Dl6C*i5[C%2lSRmP$chE$4Y%+5K8lF`&65BbT*
@@ -52,7 +52,7 @@ AAHc0P@`b$Ti)UB6#@i*,6CC*P(Hha6Kl5NLP`!%NTRK**5cQJMc3kADl5LUZ6YZ
 558T-NN%P,T***+8Q6T*+BN*!Tc`Qe#59d+mF&%h+&ZV38LSEXUa$!TU,4$3&**!
 !9****+Ire[3%NNNP+55558XN%kC*5k5C**5k5555PNNLNNT4#LjX`T*"*+NkC1N
 K55555Rrrer3%NNNP+55558T-H8kLlK*5kL6"5"51U5@5G-1%k5&NJNNNT5356Gd
-P,T***+A55558r`$rd23%NNNP+55558T-R558M)Jq58UC%U%***C0+NS0j8dP&5C
+P,T***+A55558r`$rd23%NNNP+55558T-R558M)Jq58UC%U%**"C0+NS0j8dP&5C
 1Q53T)Tda58T**1NT55555RrrdI3%NNNP+55558T****5P%U5BT+Bpe*48NNPG-8
 NNN+55558T1Q6T+8NNNNTrp,d"****5NNNNP+55558T-lK1SZi58XT"4M45#55T*
 1Q53T****5NkC1NT55555Rrr6p!55558T****5NNNNP,+2*mP***5NJNNNTG-R6*


### PR DESCRIPTION
Symbols which are seen on the whole picture https://i.warosu.org/data/lit/img/0052/57/1407621588546.jpg are fixed. CRC is still wrong. Fixed warning in the output of exiftool "Bad Photoshop IRB resource "\xecBIM"".